### PR TITLE
First step to testing aws-checker

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSigint(t *testing.T) {
+	sigs := make(chan os.Signal, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		Run(sigs)
+
+		cancel()
+	}()
+
+	sigs <- syscall.SIGINT
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout")
+	}
+}


### PR DESCRIPTION
The long term goal is to mock out AWS calls and unit-test every code path in aws-checker.

Towards that, we extract `Run(sigs)` out of `main` and test `Run` without relying on `signal.Notify`. We can then make `Run` return an error, support dependency-injection for various AWS services/clients.