### PR TITLE
Unify signal channel into context

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,7 @@ func TestSigint(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		runErr <- Run(sigs, func(c *checker) {
+		runErr <- Run(ContextWithSignal(ctx, sigs), func(c *checker) {
 			// Use localstack for S3
 			c.s3Opts = append(c.s3Opts, s3.WithEndpointResolverV2(localstack.S3EndpointResolver()))
 		})


### PR DESCRIPTION
Let's use `context.Context` for cancellation due to timeout AND a signal so that `Run` does not need to know about the signals.