### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,5 @@ jobs:
           go-version: 1.22
       - name: Goreleaser image building test
         uses: goreleaser/goreleaser-action@v6
-        args: release --snapshot
+        with:
+          args: release --snapshot

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,5 +1,6 @@
 project_name: aws-checker
 env:
+  - REGISTRY=ghcr.io/chatwork
 builds:
   - id: aws-checker
     main: ./


### PR DESCRIPTION
#28 enabled testing goreleaser builds.
Now, we automate the release publishing process by triggering goreleaser on tagged commits!