### PR TITLE
ci: Remove unnecesary contents:write permission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{fromJson(needs.setup.outputs.matrix)}}
-    permissions:
-      # This is required to push changes back to the repository
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
Since #40 we no longer need the `contents:write` permission for the `test` job.