### PR TITLE
Remove and fix ldflags related to version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,6 @@
 GOLANGCI_LINT_VERSION=1.56.2
-TAG  ?= $(shell git describe --tags --abbrev=0 HEAD || echo dev)
-DATE_FMT = +"%Y-%m-%dT%H:%M:%S%z"
-ifdef SOURCE_DATE_EPOCH
-    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
-else
-    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
-endif
 
-GO_BUILD_VERSION_LDFLAGS=\
-  -X go.szostok.io/version.version=$(TAG) \
-  -X go.szostok.io/version.buildDate=$(BUILD_DATE) \
-  -X go.szostok.io/version.commit=$(shell git rev-parse --short HEAD) \
-  -X go.szostok.io/version.commitDate=$(shell git log -1 --date=format:"%Y-%m-%dT%H:%M:%S%z" --format=%cd) \
-  -X go.szostok.io/version.dirtyBuild=false
+GO_BUILD_VERSION_LDFLAGS=-X main.Version=$(shell git rev-parse --short HEAD)
 
 .PHONY: build
 build:


### PR DESCRIPTION
The only ldflag we need is `-X main.Version=$VERSION` as we already do for goreleaser.