### PR TITLE
Set concurrency for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yaml
+++ b/.github/workflows/dependabot_auto_merge.yaml
@@ -5,6 +5,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: dependabot-auto-merge-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should prevent potential failures on dependabot force-pushing the PRs and triggering concurrent merges.