### PR TITLE
autotagpatch: Do not fail when no commits to tag

### DIFF
--- a/tools/autotagpatch/main.go
+++ b/tools/autotagpatch/main.go
@@ -202,7 +202,8 @@ LOOP:
 	}
 
 	if len(commits) == 0 {
-		return nil, fmt.Errorf("no new commits found since tag %s", *tag.Name)
+		log.Printf("no new commits found since tag %s", *tag.Name)
+		return nil, nil
 	}
 
 	slices.Reverse(commits)


### PR DESCRIPTION
`autotagpatch` is failing like [this](https://github.com/chatwork/aws-checker/actions/runs/12461314945/job/34780713233) when there are no commits to tag. It's normal and we don't need to mark it as a failure.