### PR TITLE
Use GitHub App for auto patch tagging

### DIFF
--- a/.github/workflows/auto_patch_release.yaml
+++ b/.github/workflows/auto_patch_release.yaml
@@ -5,17 +5,20 @@ on:
     # Run every day at 4:30 UTC = 13:30 JST
     - cron: '30 4 * * *'
 
-permissions:
-  contents: write
-
 jobs:
   auto_patch_release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
     - uses: actions/setup-go@v5
     - run: |
         cd ./tools/autotagpatch
         go run .
       env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
v0.1.4 was tagged automatically but didn't trigger the release workflow.
I believe this is due to the use of the default github token associated to `github-actions[bot]`.
