### PR TITLE
Add more DynamoDB checks

### DIFF
--- a/main.go
+++ b/main.go
@@ -320,7 +320,10 @@ func (c *checker) doCheckDynamoDB(ctx context.Context) {
 				_, err := c.dynamoClient.Query(ctx, &dynamodb.QueryInput{
 					TableName:              &c.dynamodbTable,
 					KeyConditionExpression: aws.String("id = :id"),
-					ConsistentRead:         aws.Bool(true),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":id": &dynamodbtypes.AttributeValueMemberS{Value: "test-id"},
+					},
+					ConsistentRead: aws.Bool(true),
 				})
 				return err
 			},


### PR DESCRIPTION
I see unbelievably and consistently low DynamoDB latencies so was curious how it is for other metrics :)

I also added an abstraction over the checks so that we can extend this to other services like SQS and S3 without bloating the code base.
