### PR TITLE
Add group settings to dependabot's gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  groups:
+      gomod:
+        patterns:
+          - "*"
 - package-ecosystem: "docker"
   directory: "/"
   schedule:


### PR DESCRIPTION
Add group settings to dependabot's gomod

See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--