### PR TITLE
Fix test not panic with `Invalid name validation scheme requested: unset`

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/cw-sakamoto/sample/localstack"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -323,7 +324,7 @@ type labels struct {
 }
 
 func parseMetrics(t *testing.T, m string) (map[labels]struct{}, error) {
-	p := expfmt.TextParser{}
+	p := expfmt.NewTextParser(model.UTF8Validation)
 	mf, err := p.TextToMetricFamilies(strings.NewReader(m))
 	require.NoError(t, err)
 


### PR DESCRIPTION
This resolves the build failure that has been occurring since #188.

In short, the build failure was due to the prometheus/common module failing when a validation schema is not set, which likely indicates that we need to choose either `LegacyValidation` or `UTF8Validation`. The former is for Prometheus 2.x compatibility, while the latter is for Prometheus 3.x and greater.

https://pkg.go.dev/github.com/prometheus/common/model#ValidationScheme

References:

- https://prometheus.io/docs/prometheus/latest/migration/#utf-8-names says Prometheus 3 supports utf8 metric name and labels